### PR TITLE
Fix path segment detection for non-canonical paths

### DIFF
--- a/src/Path/Base.php
+++ b/src/Path/Base.php
@@ -150,7 +150,21 @@ abstract class Base implements Path
      */
     private function detectSegments(string $path)
     {
-        $this->segments = empty($path) ? [] : explode('/', trim($path, '/'));
+        $segments = empty($path) ? [] : explode('/', trim($path, '/'));
+        $segments = array_filter($segments);
+        $this->segments = [];
+
+        foreach ($segments as $segment) {
+            if ($segment === '.') {
+                continue;
+            }
+            if ($segment === '..') {
+                array_pop($this->segments);
+            } else {
+                $this->segments[] = $segment;
+            }
+        }
+
         $this->depth    = count($this->segments);
     }
 


### PR DESCRIPTION
While the proper solution would entail a call to `realpath`, and therefore this fix is
sloppy at best, it stays in line with being agnostic towards the actual filesystem

The issue was detected given those two paths:
- `/path/to/parent/child/file.ext`
- `/path/to/parent/child/..`

The second path was not properly detected as "parent" of the first one, as they
differed in the last segment